### PR TITLE
Adds Basic Auth to all resources loaded by a page

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -390,7 +390,12 @@ class Ghost(object):
         request = QNetworkRequest(QUrl(address))
         if auth is not None:
             auth_type, username, password = auth
-            http_auth(request, auth_type, username, password)
+
+            def authenticate(reply, authenticator):
+                authenticator.setUser(username)
+                authenticator.setPassword(password)
+
+            self.page.networkAccessManager().authenticationRequired.connect(authenticate)
         if not "User-Agent" in headers:
             headers["User-Agent"] = self.user_agent
         for header in headers:
@@ -398,6 +403,7 @@ class Ghost(object):
         self.main_frame.load(request, method, body)
         self.loaded = False
         return self.wait_for_page_loaded()
+
 
     class prompt:
         """Statement that tells Ghost how to deal with javascript prompt().


### PR DESCRIPTION
This is in relation to issue #11.

This fix will ensure that if you open a page with basic auth, all the resources loaded by the page will also be opened with the same authorization details.

I tested this change for basic authentication on PyQt but not for PySide or for proxy authentication.

Thanks!
