### PR TITLE
Force request to ignore cache

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -392,6 +392,7 @@ class Ghost(object):
         except AttributeError:
             raise Exception("Invalid http method %s" % method)
         request = QNetworkRequest(QUrl(address))
+        request.CacheLoadControl(0)
         if not "User-Agent" in headers:
             headers["User-Agent"] = self.user_agent
         for header in headers:


### PR DESCRIPTION
Even with QWebSettings.setMaximumPagesInCache(0) and
QWebSettings.setObjectCacheCapacities(0, 0, 0), response data is still
cached if the Expires header is less than current time.
CacheLoadControl(0) forces the request to pull from the network.
