### PR TITLE
Correct source path of symlink for PySide

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,5 @@ install:
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - ln -s /usr/lib/pymodules/python2.7/PySide /home/vagrant/virtualenv/python2.7/lib/python2.7/site-packages/PySide -v
+  - ln -s /usr/lib/python2.7/dist-packages/PySide /home/vagrant/virtualenv/python2.7/lib/python2.7/site-packages/PySide -v
 script: tests/run.py -v
-


### PR DESCRIPTION
Before this change, Travis CI builds were failing with:

```
Exception: Ghost.py requires PySide or PyQt
```

Here's the Travis CI build for my fork with this change: http://travis-ci.org/#!/msabramo/Ghost.py

There are still two test failures, but it gets much further than it did before, as before it immediately errored out because it couldn't find PySide.
