### PR TITLE
Correctly set the User Agent header.

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -98,6 +98,12 @@ class GhostWebPage(QtWebKit.QWebPage):
         result.append(result_value)
         return True
 
+    def setUserAgent(self, user_agent):
+        self.user_agent = user_agent
+
+    def userAgentForUrl(self, url):
+        return self.user_agent
+
 
 def can_load_page(func):
     """Decorator that specifies if user can expect page loading from
@@ -209,6 +215,8 @@ class Ghost(object):
         # Cookie jar
         self.cookie_jar = QNetworkCookieJar()
         self.manager.setCookieJar(self.cookie_jar)
+        # User Agent
+        self.page.setUserAgent(self.user_agent)
 
         self.page.networkAccessManager().authenticationRequired\
             .connect(self._authenticate)
@@ -402,8 +410,6 @@ class Ghost(object):
             raise Exception("Invalid http method %s" % method)
         request = QNetworkRequest(QUrl(address))
         request.CacheLoadControl(0)
-        if not "User-Agent" in headers:
-            headers["User-Agent"] = self.user_agent
         for header in headers:
             request.setRawHeader(header, headers[header])
         self._auth = auth


### PR DESCRIPTION
Setting the user agent as a header on an individual request does not actually set the sent user agent string, as QWebPage would override the header.

QWebPage has a delegate method, userAgentForUrl(url), which should return the user agent to be used. I've implemented this with two new methods on GhostWebPage
