### PR TITLE
Allow custom ServerThread class in test

### DIFF
--- a/ghost/test.py
+++ b/ghost/test.py
@@ -69,6 +69,7 @@ class GhostTestCase(BaseGhostTestCase):
     """TestCase that provides a ghost instance and manage
     an HTTPServer running a WSGI application.
     """
+    server_class = ServerThread
     port = 5000
 
     def create_app(self):
@@ -86,7 +87,7 @@ class GhostTestCase(BaseGhostTestCase):
     def setUpClass(cls):
         """Starts HTTPServer instance from WSGI application.
         """
-        cls.server_thread = ServerThread(cls.create_app(), cls.port)
+        cls.server_thread = cls.server_class(cls.create_app(), cls.port)
         cls.server_thread.daemon = True
         cls.server_thread.start()
         while not hasattr(cls.server_thread, 'http_server'):


### PR DESCRIPTION
One of my project require a custom `WSGIRequestHandler` class for custom logging but there doesn't seems to be a way to do this in Ghost.py currently. This pull request simply add `server_class` variable to allow `GhostTestCase` to use another `ServerThread`.

Thanks!
