### PR TITLE
localStorage doesn't work

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -201,6 +201,7 @@ class Ghost(object):
         self.page = GhostWebPage(Ghost._app)
         QtWebKit.QWebSettings.setMaximumPagesInCache(0)
         QtWebKit.QWebSettings.setObjectCacheCapacities(0, 0, 0)
+        QtWebKit.QWebSettings.globalSettings().setAttribute(QtWebKit.QWebSettings.LocalStorageEnabled, True)
 
         self.page.setForwardUnsupportedContent(True)
 


### PR DESCRIPTION
When loading a page that uses HTML5's localStorage, I get:

```
ERROR:ghost:Frame: http://jpmcgarrity.com/examples/html5/localStorage/(36): TypeError: Result of expression 'localStorage' [null] is not an object.
...
Exception: Unable to load requested page
```

I don't know much about PySide and QtWebKit, but a bit of googling pointed me to [this page](https://deptinfo-ensip.univ-poitiers.fr/ENS/pyside-docs/PySide/QtWebKit/QWebSettings.html#PySide.QtWebKit.PySide.QtWebKit.QWebSettings.setLocalStoragePath) which indicates that it must be explicitly enabled.
