### PR TITLE
Fix travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.7"
 install:
+  - sudo apt-get update
   - sudo apt-get install python-pyside
   - pip install -r tests/requirements.txt --use-mirrors
   - python setup.py install

--- a/README.rst
+++ b/README.rst
@@ -6,3 +6,4 @@ ghost.py is a webkit web client written in python::
     assert page.http_status==200 and 'jeanphix' in ghost.content
 
 .. image:: https://secure.travis-ci.org/jeanphix/Ghost.py.png
+   :target: https://travis-ci.org/jeanphix/Ghost.py


### PR DESCRIPTION
Travis continuous integration fails : 

```
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing? 
```

This patch just adds sudo apt-get update to `.travis.yml` and "improves" the `README.rst`. 

My 2 cents.
