### PR TITLE
Add 'use_2to3' to 'setup.py' to automatically support Python 3.x.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setup(
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
+    use_2to3=True,
 )


### PR DESCRIPTION
Running `2to3` on the source code seems to be enough to support Python 3.x. This pull request simply adds `setuptools` `use_2to3` option to `setup.py` to run `2to3` automatically during the build.
