### PR TITLE
Waits for files to be downloaded. Fixes #28

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -667,6 +667,7 @@ class Ghost(object):
 
         :param reply: The QNetworkReply object.
         """
+        self.wait_for(lambda: reply.isFinished(), 'Download timeout.')
         if reply.attribute(QNetworkRequest.HttpStatusCodeAttribute):
             self.http_resources.append(HttpResource(reply, self.cache,
                 reply.readAll()))


### PR DESCRIPTION
Just added a line that waited for the reply to be completed (in this case the whole file to be downloaded) before creating the HTTPResource. 

The problem was that when you tried to used the HTTPResource the content was only partial.

Weird, the tests are passing in my computer but not on Travis, OSX Mountain Lion, Python 2.7.2

```
test_wait_for_timeout (__main__.GhostTest) ... 1.0.0.127.in-addr.arpa - - [03/Mar/2013 15:35:12] "GET / HTTP/1.1" 200 276
INFO:ghost:Ghost: Resource loaded: http://localhost:5000/ 200
ok

----------------------------------------------------------------------
Ran 37 tests in 9.959s

OK
```
