### PR TITLE
Fix: page data not being returned when using PyQt

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -625,7 +625,11 @@ class Ghost(object):
             'Unable to load requested page')
         resources = self._release_last_resources()
         page = None
-        url = self.main_frame.url().toString()
+
+        if PYSIDE:
+            url = self.main_frame.url().toString()
+        else:
+            url = self.main_frame.url()
 
         for resource in resources:
             if url == resource.url:


### PR DESCRIPTION
This solves the issue mentioned at the bottom of #53, that page returns empty:

```
>>> from ghost import Ghost
>>> ghost = Ghost()
>>> page, extra_resources = ghost.open("http://jeanphi.fr")
>>> assert page.http_status==200 and 'jeanphix' in ghost.content
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'NoneType' object has no attribute 'http_status'
```

This is due to the use of `.toString()` on the `url` variable when using PyQt, while comparing with a `QUrl` object.
