### PR TITLE
Render whole website on capture

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -287,10 +287,10 @@ class Ghost(object):
             painter.end()
             image = image.copy(x1, y1, w, h)
         else:
-            self.page.setViewportSize(self.main_frame.contentsSize())
-            image = QImage(self.page.viewportSize(), format)
             self.main_frame.setScrollBarPolicy(QtCore.Qt.Vertical, QtCore.Qt.ScrollBarAlwaysOff)
             self.main_frame.setScrollBarPolicy(QtCore.Qt.Horizontal, QtCore.Qt.ScrollBarAlwaysOff)
+            self.page.setViewportSize(self.main_frame.contentsSize())
+            image = QImage(self.page.viewportSize(), format)
             painter = QPainter(image)
             self.main_frame.render(painter)
             painter.end()


### PR DESCRIPTION
The capture of a eg. 800x600px window with scrollbars has limited use. Therefore the capture should contain the complete website.
This doesn't affect the ui.
