### PR TITLE
Fix viewport being reset to 800x600 on ui-show

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -254,7 +254,10 @@ class Ghost(object):
         logger.setLevel(log_level)
 
         if self.display:
-            self.webview = QtWebKit.QWebView()
+            class MyQWebView(QtWebKit.QWebView):
+                def sizeHint(self):
+                    return QSize(*viewport_size)
+            self.webview = MyQWebView()
             if plugins_enabled:
                 self.webview.settings().setAttribute(QtWebKit.QWebSettings.PluginsEnabled, True)
             if java_enabled:


### PR DESCRIPTION
The SizeHint in QWebView is hardcoded to 800x600px
(see http://qt-project.org/forums/viewthread/20010)

This patch will use the configured viewport_size as SizeHint.
