### PR TITLE
Feature: added support for collecting popup (confirm/alert/prompt) messages and default value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 *.swp
 *.swo
 .tox
+.idea

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -54,6 +54,10 @@ class GhostWebPage(QtWebKit.QWebPage):
     behaviours like alert(), confirm().
     Also intercepts client side console.log().
     """
+    def __init__(self, app, ghost):
+        self.ghost = ghost
+        super(GhostWebPage, self).__init__(app)
+
     def chooseFile(self, frame, suggested_file=None):
         return Ghost._upload_file
 
@@ -68,6 +72,7 @@ class GhostWebPage(QtWebKit.QWebPage):
     def javaScriptAlert(self, frame, message):
         """Notifies ghost for alert, then pass."""
         Ghost._alert = message
+        self.ghost.append_popup_message(message)
         Logger.log("alert('%s')" % message, sender="Frame")
 
     def javaScriptConfirm(self, frame, message):
@@ -77,6 +82,7 @@ class GhostWebPage(QtWebKit.QWebPage):
         if Ghost._confirm_expected is None:
             raise Exception('You must specified a value to confirm "%s"' %
                 message)
+        self.ghost.append_popup_message(message)
         confirmation, callback = Ghost._confirm_expected
         Ghost._confirm_expected = None
         Logger.log("confirm('%s')" % message, sender="Frame")
@@ -91,6 +97,7 @@ class GhostWebPage(QtWebKit.QWebPage):
         if Ghost._prompt_expected is None:
             raise Exception('You must specified a value for prompt "%s"' %
                 message)
+        self.ghost.append_popup_message(message)
         result_value, callback = Ghost._prompt_expected
         Logger.log("prompt('%s')" % message, sender="Frame")
         if callback is not None:
@@ -213,7 +220,8 @@ class Ghost(object):
                 for p in plugin_path:
                     Ghost._app.addLibraryPath(p)
 
-        self.page = GhostWebPage(Ghost._app)
+        self.popup_messages = []
+        self.page = GhostWebPage(Ghost._app, self)
         QtWebKit.QWebSettings.setMaximumPagesInCache(0)
         QtWebKit.QWebSettings.setObjectCacheCapacities(0, 0, 0)
         QtWebKit.QWebSettings.globalSettings().setAttribute(QtWebKit.QWebSettings.LocalStorageEnabled, True)
@@ -222,7 +230,6 @@ class Ghost(object):
         self.page.settings().setAttribute(QtWebKit.QWebSettings.AutoLoadImages, download_images)
         self.page.settings().setAttribute(QtWebKit.QWebSettings.PluginsEnabled, plugins_enabled)
         self.page.settings().setAttribute(QtWebKit.QWebSettings.JavaEnabled, java_enabled)
-
 
         self.set_viewport_size(*viewport_size)
 
@@ -390,6 +397,10 @@ class Ghost(object):
         """Deletes all cookies."""
         self.cookie_jar.setAllCookies([])
 
+    def clear_alert_message(self):
+        """Clears the alert message"""
+        self._alert = None
+
     @can_load_page
     def evaluate(self, script):
         """Evaluates script in page frame.
@@ -505,7 +516,8 @@ class Ghost(object):
         else:
             raise ValueError, 'unsupported cookie_storage type.'
 
-    def open(self, address, method='get', headers={}, auth=None, body=None):
+    def open(self, address, method='get', headers={}, auth=None, body=None,
+             default_popup_response=None):
         """Opens a web page.
 
         :param address: The resource URL.
@@ -513,12 +525,15 @@ class Ghost(object):
         :param headers: An optional dict of extra request hearders.
         :param auth: An optional tupple of HTTP auth (username, password).
         :param body: An optional string containing a payload.
+        :param default_popup_response: the default response for any confirm/
+        alert/prompt popup from the Javascript (replaces the need for the with
+        blocks)
         :return: Page resource, All loaded resources.
         """
         body = body or QByteArray()
         try:
             method = getattr(QNetworkAccessManager,
-                "%sOperation" % method.capitalize())
+                             "%sOperation" % method.capitalize())
         except AttributeError:
             raise Exception("Invalid http method %s" % method)
         request = QNetworkRequest(QUrl(address))
@@ -530,6 +545,8 @@ class Ghost(object):
 
         self.main_frame.load(request, method, body)
         self.loaded = False
+        Ghost._prompt_expected = (default_popup_response, None)
+        Ghost._confirm_expected = (default_popup_response, None)
 
         return self.wait_for_page_loaded()
 
@@ -704,6 +721,9 @@ class Ghost(object):
         :param height: An integer that sets height pixel count.
         """
         self.page.setViewportSize(QSize(width, height))
+
+    def append_popup_message(self, message):
+        self.popup_messages.append(str(message))
 
     def show(self):
         """Show current page inside a QWebView.

--- a/ghost/test.py
+++ b/ghost/test.py
@@ -55,6 +55,7 @@ class BaseGhostTestCase(TestCase):
     def _post_teardown(self):
         """Deletes ghost cookies and hide UI if needed."""
         self.ghost.delete_cookies()
+        self.ghost.clear_alert_message()
         if self.display:
             self.ghost.hide()
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -184,6 +184,27 @@ class GhostTest(GhostTestCase):
         value, resources = self.ghost.evaluate('promptValue')
         self.assertEqual(value, 'another value')
 
+    def test_popup_messages_collection(self):
+        self.ghost.open("%salert" % base_url, default_popup_response=True)
+        self.ghost.click('#confirm-button')
+        self.assertIn('this is a confirm', self.ghost.popup_messages)
+        self.ghost.click('#prompt-button')
+        self.assertIn('Prompt ?', self.ghost.popup_messages)
+        self.ghost.click('#alert-button')
+        self.assertIn('this is an alert', self.ghost.popup_messages)
+
+    def test_prompt_default_value_true(self):
+        self.ghost.open("%salert" % base_url, default_popup_response=True)
+        self.ghost.click('#confirm-button')
+        msg, resources = self.ghost.wait_for_alert()
+        self.assertEqual(msg, 'you confirmed!')
+
+    def test_prompt_default_value_false(self):
+        self.ghost.open("%salert" % base_url, default_popup_response=False)
+        self.ghost.click('#confirm-button')
+        msg, resources = self.ghost.wait_for_alert()
+        self.assertEqual(msg, 'you denied!')
+
     def test_capture_to(self):
         self.ghost.open(base_url)
         self.ghost.capture_to('test.png')


### PR DESCRIPTION
Feature: added support for collecting popup (confirm/alert/prompt) messages and providing default value for different Javascript popups.
1. All the different popup messages collected in popup_messages list.
2. You can pass default value to use for confirm/alert/prompt dialogs, without
   the need to use the with statement (in case you just want the popup to go away).
3. Little refactoring to GhostWebPage: I'm passing the Ghost object to it,
   so we won't need to use global variables. This refacotring can later be applied
   to _alert and similar variables.
