### PR TITLE
Fix: if final URL contains hash, no page contents will be returned.

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -745,6 +745,7 @@ class Ghost(object):
         page = None
 
         url = self.main_frame.url().toString()
+        url = url.split("#")[0]
 
         for resource in resources:
             if url == resource.url:

--- a/tests/app.py
+++ b/tests/app.py
@@ -117,6 +117,10 @@ def send_file():
     return Response(open(os.path.join(os.path.dirname(__file__), 'static',
         'foo.tar.gz'), 'r'), headers=h)
 
+@app.route('/url-hash')
+def url_hash():
+    return render_template('url_hash.html')
+
 
 if __name__ == '__main__':
     app.run()

--- a/tests/run.py
+++ b/tests/run.py
@@ -290,6 +290,10 @@ class GhostTest(GhostTestCase):
         'foo.tar.gz'), 'r').read(1024)
         self.assertEqual(resources[0].content, foo)
 
+    def test_url_with_hash(self):
+        page, resources = self.ghost.open("%surl-hash" % base_url)
+        self.assertIsNotNone(page)
+        self.assertTrue("Test page" in self.ghost.content)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/templates/url_hash.html
+++ b/tests/templates/url_hash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+    <body>
+        <h1>Test page</h1>
+        <p>This is the home page.</p>
+        <p><a href="{{ url_for('form') }}">This is a clickable link</a></p>
+        <script type="text/javascript">
+            document.location.hash = "test";
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
When the final URL contains a hash (which is not part of the URL that is sent to the server) it will be different from the one that the resource has, for example:

Resource URL: `http://m.youtube.com/index?&desktop_uri=/`
Main frame URL: `http://m.youtube.com/index?&desktop_uri=/#/home`
(you can reproduce this by opening http://youtube.com/ with iPhone's user agent)

This results in `open` not returning page data. 

The way I fix it is by stripping everything after the `#` in the frame url, before comparing it with the resource URL.

Another similar bug that might happen is if our WebKit version supports [pushState](http://badassjs.com/post/840846392/location-hash-is-dead-long-live-html5-pushstate). If it does, the main_frame url might end up being completely different than the one the resource has. In this case, we might want to switch to using the `main_frame.toHtml()` method, but it has the downside of loosing the headers and HTTP status code information. 

Therefore for now I'm just submitting solution for the hash issue.

(the Travis build fails, but only because of the unsupported_content test)
