### PR TITLE
Fix: Support for URLs with hashes that are sent to server.

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -776,10 +776,10 @@ class Ghost(object):
         page = None
 
         url = self.main_frame.url().toString()
-        url = url.split("#")[0]
+        url_without_hash = url.split("#")[0]
 
         for resource in resources:
-            if url == resource.url:
+            if url == resource.url or url_without_hash == resource.url:
                 page = resource
         return page, resources
 

--- a/tests/app.py
+++ b/tests/app.py
@@ -121,6 +121,17 @@ def send_file():
 def url_hash():
     return render_template('url_hash.html')
 
+@app.route('/url-hash-header')
+def url_hash_header():
+    response = make_response("Redirecting.", 302)
+    response.headers['Location'] = url_for('url_hash_header_redirect') + "#/"
+    return response
+
+@app.route('/url-hash-header-redirect/')
+def url_hash_header_redirect():
+    return "Welcome."
+
+
 
 if __name__ == '__main__':
     app.run()

--- a/tests/run.py
+++ b/tests/run.py
@@ -296,5 +296,10 @@ class GhostTest(GhostTestCase):
         self.assertIsNotNone(page)
         self.assertTrue("Test page" in self.ghost.content)
 
+    def test_url_with_hash_header(self):
+        page, resources = self.ghost.open("%surl-hash-header" % base_url)
+        self.assertIsNotNone(page)
+        self.assertTrue("Welcome" in self.ghost.content)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When the server redirects the browser using a location header that contains a hash, this hash will be preserved in the resource URL.

Because in pull request #80 we started stripping the part after the hash, we can no longer find the page resource in such cases.

I've applied a solution but it still feels shaky. How about we stop retrieving the page data from the resources, but take it from the main_frame object (by calling `getHtml()`)? 

The downside is that we no longer will have HTTP status code or headers, but I think that those who need them can work directly with the resources while everyone else can use the page object for the page HTML.
