### PR TITLE
Few fixes to the popup collection feature

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -102,7 +102,6 @@ class GhostWebPage(QtWebKit.QWebPage):
             raise Exception('You must specified a value to confirm "%s"' % message)
         self.ghost.append_popup_message(message)
         confirmation, callback = Ghost._confirm_expected
-        Ghost._confirm_expected = None
         Logger.log("confirm('%s')" % message, sender="Frame")
         if callback is not None:
             return callback()
@@ -123,7 +122,7 @@ class GhostWebPage(QtWebKit.QWebPage):
         if result_value == '':
             Logger.log("'%s' prompt filled with empty string" % message,
                 level='warning')
-        Ghost._prompt_expected = None
+
         if result is None:
             # PySide
             return True, result_value


### PR DESCRIPTION
I've made few fixes to the popup collection feature:
1. Converting the popup message to unicode instead of str (otherwise it will crash on unicode text).
2. Making sure the result of `Ghost._prompt_expected` is always a string, but if it's a boolean it raises an error (and it can be a boolean when using default_popup_response).
3. I removed the clearing of `Ghost._confirm_expected`/`Ghost._prompt_expected` in `GhostWebPage.javascriptPrompt` and `GhostWebPage.javascriptConfirm`, because it gets cleared anyway in the context handlers.
