### PR TITLE
Add zoom_factor param to capture() and capture_to().

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -307,14 +307,21 @@ class Ghost(object):
         self.exit()
 
     def capture(self, region=None, selector=None,
-            format=QImage.Format_ARGB32_Premultiplied):
+            format=QImage.Format_ARGB32_Premultiplied, zoom_factor=1.0):
         """Returns snapshot as QImage.
 
         :param region: An optional tuple containing region as pixel
             coodinates.
         :param selector: A selector targeted the element to crop on.
         :param format: The output image format.
+        :param zoom_factor: Scales the output image.
         """
+        
+        if self.webview is None:
+          self.webview = QtWebKit.QWebView()
+          self.webview.setPage(self.page)
+        self.webview.setZoomFactor(zoom_factor)    
+    
         if region is None and selector is not None:
             region = self.region_for_selector(selector)
         if region:
@@ -336,7 +343,7 @@ class Ghost(object):
         return image
 
     def capture_to(self, path, region=None, selector=None,
-        format=QImage.Format_ARGB32_Premultiplied):
+        format=QImage.Format_ARGB32_Premultiplied, zoom_factor=1.0):
         """Saves snapshot as image.
 
         :param path: The destination path.
@@ -344,9 +351,10 @@ class Ghost(object):
             coodinates.
         :param selector: A selector targeted the element to crop on.
         :param format: The output image format.
+        :param zoom_factor: Scales the output image.
         """
         self.capture(region=region, format=format,
-                     selector=selector).save(path)
+                     selector=selector, zoom_factor=zoom_factor).save(path)
 
     def print_to_pdf(self,
                      path,


### PR DESCRIPTION
I needed the ability to capture high-resolution screenshots (analogous to what phantomjs' rasterize.js offers), so I added a zoom_factor parameter to Ghost.capture() and Ghost.capture_to(). I followed the pattern that I saw in Ghost.print_to_pdf(), which also has a zoom_factor parameter. 

I'm sending a pull request in case this helps, but no need to merge in if you don't want this. Or let me know if it should be implemented differently or refactored somehow.
