### PR TITLE
Don't rely on how the type in an input field is set.

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -723,7 +723,7 @@ class Ghost(object):
         elif element.tagName() == "TEXTAREA":
             _set_textarea_value(element, value)
         elif element.tagName() == "INPUT":
-            if element.attribute('type') in ["color", "date", "datetime",
+            if element.attribute('type').lower() in ["color", "date", "datetime",
                 "datetime-local", "email", "hidden", "month", "number",
                 "password", "range", "search", "tel", "text", "time",
                 "url", "week"]:

--- a/tests/templates/form.html
+++ b/tests/templates/form.html
@@ -15,7 +15,7 @@
             <fieldset>
                 <p>
                     <label for="text">text</label>
-                    <input type="text" id="text" name="text" />
+                    <input type="TEXT" id="text" name="text" />
                 </p>
                 <p>
                     <label for="email">email</label>


### PR DESCRIPTION
The type in an HTML form could be set upper case. In this case the code
seem to work fine, but doesn't set any value in the input field. This
commit takes these cases in consideration and fixes #117
