### PR TITLE
Allow working with default input type and frames

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -321,13 +321,13 @@ class Ghost(object):
     def __del__(self):
         self.exit()
 
-    def ascendToRootFrame(self):
+    def ascend_to_root_frame(self):
         """ Set main frame as current main frame's parent.
         """
         # we can't ascend directly to parent frame because it might have been deleted
         self.main_frame = self.page.mainFrame()
 
-    def descendFrame(self, child_name):
+    def descend_frame(self, child_name):
         """ Set main frame as one of current main frame's children.
 
         :param child_name: The name of the child to descend to.


### PR DESCRIPTION
- Allow set_field_value to recognize that an input element with no type defaults to the text type
- Ability to descend frame and jump back to root frame
- Before, if an input field has no type set, we could not set its value and working with frames was impossible without some hacking. Now, set_field_value recognizes that an input field with no type defaults to the text type and we can work with frames by going down the hierarchy using descend_frame or jumping right up to root using ascend_to_root_frame
