### PR TITLE
Change Default SSL Configuration

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -13,7 +13,7 @@ try:
     from PySide import QtWebKit
     from PySide.QtNetwork import QNetworkRequest, QNetworkAccessManager, \
                                  QNetworkCookieJar, QNetworkDiskCache, \
-                                 QNetworkProxy, QNetworkCookie
+                                 QNetworkProxy, QNetworkCookie, QSslConfiguration, QSsl
     from PySide import QtCore
     from PySide.QtCore import QSize, QByteArray, QUrl, QDateTime, \
                               QtCriticalMsg, QtDebugMsg, QtFatalMsg, \
@@ -27,7 +27,7 @@ except ImportError:
         from PyQt4 import QtWebKit
         from PyQt4.QtNetwork import QNetworkRequest, QNetworkAccessManager, \
                                     QNetworkCookieJar, QNetworkDiskCache,  \
-                                    QNetworkProxy, QNetworkCookie
+                                    QNetworkProxy, QNetworkCookie, QSslConfiguration, QSsl
         from PyQt4 import QtCore
         from PyQt4.QtCore import QSize, QByteArray, QUrl, QDateTime, \
                                  QtCriticalMsg, QtDebugMsg, QtFatalMsg, \
@@ -224,7 +224,7 @@ class Ghost(object):
             cache_dir=os.path.join(tempfile.gettempdir(), "ghost.py"),
             plugins_enabled=False, java_enabled=False,
             plugin_path=['/usr/lib/mozilla/plugins', ],
-            download_images=True, qt_debug=False,
+            download_images=True, qt_debug=False, no_sslv3 = True,
             show_scroolbars=True):
         self.http_resources = []
 
@@ -251,6 +251,15 @@ class Ghost(object):
             if plugin_path:
                 for p in plugin_path:
                     Ghost._app.addLibraryPath(p)
+
+
+
+        if no_sslv3:
+            # enable tls1 only
+            old = QSslConfiguration.defaultConfiguration()
+            old.setProtocol(QSsl.TlsV1)
+            QSslConfiguration.setDefaultConfiguration(old)
+
 
         self.popup_messages = []
         self.page = GhostWebPage(Ghost._app, self)


### PR DESCRIPTION
The default SSL configuration has problems negotiating the TLS bits on some sites. Setting TLSv1 as the only protocol choice, got alot more (at least the set I cared about) to work. 

After a bit more investigation, I think the specific sets of MS IIS servers I'm hitting have cipher/protocol specs that are incompatible with the otherside. Anyways, no SSLv3 solves my problem, which for now is scraping some websites.
