### PR TITLE
Allow *not* to use cache to prevent "too many open files" error

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -173,14 +173,12 @@ class HttpResource(object):
     def __init__(self, reply, cache, content=None):
         self.url = reply.url().toString()
         self.content = content
-        if self.content is None:
+        if cache and self.content is None:
             # Tries to get back content from cache
             if PYSIDE:
-	    	if cache:
-                	buffer = cache.data(reply.url().toString())
+                buffer = cache.data(reply.url().toString())
             else:
-	    	if cache:
-                	buffer = cache.data(reply.url())
+                buffer = cache.data(reply.url())
             if buffer is not None:
                 content = buffer.readAll()
         try:


### PR DESCRIPTION
QNetworkDiskCache seem to be leaking file descriptors on some systems (?). I have seen this on my servers and it was reported in Ghost.py issues for a number of times too. As a workaround I patched Ghost class to allow no caching. This definitely will have impact on repeated requests, but if you fetch a lot of different sites it will prevent the process from crashing.
