### PR TITLE
Update ghost.py

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -609,7 +609,6 @@ class Ghost(object):
         :param keep_old: Don't reset, keep cookies not overridden.
         """
         def toQtCookieJar(PyCookieJar, QtCookieJar):
-            #allCookies = QtCookieJar.cookies if keep_old else []
             allCookies = QtCookieJar.allCookies() if keep_old else []
             for pc in PyCookieJar:
                 qc = toQtCookie(pc)


### PR DESCRIPTION
It seems that QNetworkCookieJar has not attribute named "cookies" but protected method "allCookies()" :p
