### PR TITLE
fix crash on 401 if _auth is None

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -961,7 +961,7 @@ class Ghost(object):
         :param mix: The QNetworkReply or QNetworkProxy object.
         :param authenticator: The QAuthenticator object.
         """
-        if self._auth_attempt == 0:
+        if self._auth is not None and self._auth_attempt == 0:
             username, password = self._auth
             authenticator.setUser(username)
             authenticator.setPassword(password)


### PR DESCRIPTION
Before this change, _authenticate would crash on line 965 if authentication was required when opening a page but auth was left at its default value of None.
