### PR TITLE
ensure sleep and process_events are called at least once during a ghost sleep call

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -881,10 +881,10 @@ class Ghost(object):
 
     def sleep(self, value):
         started_at = time.time()
-        while True:
-            if time.time() > (started_at + value):
-                break
 
+        time.sleep(0)
+        Ghost._app.processEvents()
+        while time.time() <= (started_at + value):
             time.sleep(0.01)
             Ghost._app.processEvents()
 


### PR DESCRIPTION
Previously, if ghost.sleep was called with a small (or 0) value it was possible to break out of the while loop during the first check without ever calling time.sleep or Ghost._app.processEvents
