### PR TITLE
Fix README example URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ ghost.py is a webkit web client written in python::
 
     from ghost import Ghost
     ghost = Ghost()
-    page, extra_resources = ghost.open("http://jeanphi.fr")
+    page, extra_resources = ghost.open("http://jeanphix.me")
     assert page.http_status==200 and 'jeanphix' in ghost.content
 
 .. image:: https://secure.travis-ci.org/jeanphix/Ghost.py.png


### PR DESCRIPTION
The old one wasn't active, this one works as intended
