### PR TITLE
Fixed Ghost.capture() when using selectors/regions

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -412,7 +412,6 @@ class Ghost(object):
             QtCore.Qt.ScrollBarAlwaysOff)
         self.main_frame.setScrollBarPolicy(QtCore.Qt.Horizontal,
             QtCore.Qt.ScrollBarAlwaysOff)
-        print(self.main_frame.contentsSize())
         self.page.setViewportSize(self.main_frame.contentsSize())
         image = QImage(self.page.viewportSize(), format)
         painter = QPainter(image)
@@ -421,7 +420,6 @@ class Ghost(object):
         
         if region is None and selector is not None:
             region = self.region_for_selector(selector)
-            print(region)
         
         if region:
             x1, y1, x2, y2 = region


### PR DESCRIPTION
For a quick preview of the fix, run 

```
from ghost import Ghost
ghost = Ghost(wait_timeout=10)
ghost.open('https://en.wikipedia.org/wiki/Super_Mario_Bros.')
ghost.capture_to('pic.png', selector='div#mw-content-text')
```

with and without the fix.

The bug occured in Windows with Python 2.7

What I did:

1 - The image was getting cropped, only the top would show. I used the `setScrollBarPolicy` and `setViewportSize` as it was used without the regions.
2 - The image was getting cropped when screenshotting dinamic elements. The page had to be rendered before getting the element's region.

It is slightly less efficient, as it always renders the whole page, but it works.
