### PR TITLE
Add __version__

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -9,6 +9,7 @@ import tempfile
 from functools import wraps
 from cookielib import Cookie, LWPCookieJar
 
+__version__ = "0.1b3"
 
 bindings = ["PySide", "PyQt4"]
 


### PR DESCRIPTION
Added __version__ attr to package so that scripts that check local
packages to see if newer versions are available can work.

Almost all Python packages have a version attr, and the vast majority of
them name it "__version__"
