### PR TITLE
Optional client_certificate param for Ghost.open

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -759,7 +759,7 @@ class Ghost(object):
                 ssl_conf.setLocalCertificate(certificate)
 
             if "key_path" in client_certificate:
-                private_path = QtNetwork.QSslKey(
+                private_key = QtNetwork.QSslKey(
                                     open(client_certificate["key_path"]).read(), 
                                     QSsl.Rsa) 
                 ssl_conf.setPrivateKey(private_key)


### PR DESCRIPTION
Added "client_certificate" param to expose Qt client side certificate functionality.
