### PR TITLE
Follow HTTP redirects

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -252,6 +252,7 @@ class Ghost(object):
     :param plugin_path: Array with paths to plugin directories
         (default ['/usr/lib/mozilla/plugins'])
     :param download_images: Indicate if the browser should download images
+    :param follow_redirects: Follow HTTP redirects
     """
     _alert = None
     _confirm_expected = None
@@ -274,6 +275,7 @@ class Ghost(object):
             download_images=True,
             qt_debug=False,
             show_scrollbars=True,
+            follow_redirects=True,
             network_access_manager_class=None):
 
         self.http_resources = []
@@ -320,6 +322,9 @@ class Ghost(object):
             QtWebKit.QWebSettings.PluginsEnabled, plugins_enabled)
         self.page.settings().setAttribute(QtWebKit.QWebSettings.JavaEnabled,
             java_enabled)
+        
+        if follow_redirects:
+            self.page.setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
 
         if not show_scrollbars:
             self.page.mainFrame().setScrollBarPolicy(QtCore.Qt.Vertical,

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -324,7 +324,7 @@ class Ghost(object):
             java_enabled)
         
         if follow_redirects:
-            self.page.setLinkDelegationPolicy(QWebPage.DelegateAllLinks)
+            self.page.setLinkDelegationPolicy(QtWebKit.QWebPage.DelegateAllLinks)
 
         if not show_scrollbars:
             self.page.mainFrame().setScrollBarPolicy(QtCore.Qt.Vertical,


### PR DESCRIPTION
This commit introduces a new Ghost() option `follow_redirects` (default is `True`) which will make Ghost follow HTTP redirects in destination pages. The rationale is that redirects are frequent response in real life - for example `http://google.com` will immediately redirect to `http://www.google.com/` because this is their canonical URL. Currently Ghost will just get stuck on the first redirect response with no content available.