### PR TITLE
logger.py cause ValueError: Invalid format string

### DIFF
--- a/ghost/logger.py
+++ b/ghost/logger.py
@@ -23,7 +23,7 @@ def configure(name, sender, level, handler):
     # Configure handler formater
     formatter = Formatter(
         '%(asctime)s %(sender)s: %(message)s',
-        datefmt='%Y-%m-%dT%H:%M:%S.%s',
+        datefmt='%Y-%m-%dT%H:%M:%S',
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)


### PR DESCRIPTION
Because of date format in logger.py, ValueError occurs.

```
    formatter = Formatter(
        '%(asctime)s %(sender)s: %(message)s',
        datefmt='%Y-%m-%dT%H:%M:%S.%s',
    )
```

As far as I searched the Python document, `%s` is not supported.

* [Python 2.7 strftime](https://docs.python.org/2.7/library/time.html#time.strftime)
* [Python 3.4 strftime](https://docs.python.org/3.4/library/time.html#time.strftime)

So I deleted `%s` part.
