### PR TITLE
logger.py  ValueError

### DIFF
--- a/ghost/logger.py
+++ b/ghost/logger.py
@@ -22,8 +22,8 @@ def configure(name, sender, level, handler):
     logger.setLevel(level)
     # Configure handler formater
     formatter = Formatter(
-        '%(asctime)s %(sender)s: %(message)s',
-        datefmt='%Y-%m-%dT%H:%M:%S.%s',
+        '%(asctime)s.%(msecs)03d %(sender)s: %(message)s',
+        datefmt='%Y-%m-%dT%H:%M:%S',
     )
     handler.setFormatter(formatter)
     logger.addHandler(handler)


### PR DESCRIPTION
%s is not supported in time.strftime function（python2.7 & python3.4）