### PR TITLE
Capture fails when frame size > 23170x23170

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -505,7 +505,18 @@ class Ghost(object):
             QtCore.Qt.Horizontal,
             QtCore.Qt.ScrollBarAlwaysOff,
         )
-        self.page.setViewportSize(self.main_frame.contentsSize())
+        self.logger.info(self.main_frame.contentsSize())
+        frame_size = self.main_frame.contentsSize()
+        max_size = 23170 * 23170
+        if frame_size.height() * frame_size.width() > max_size:
+            self.logger.warn("Frame size is too large.")
+            default_size = self.page.viewportSize()
+            if default_size.height() * default_size.width() > max_size:
+                return None
+        else:
+            self.page.setViewportSize(self.main_frame.contentsSize())
+        self.logger.info("Frame size -> " + str(self.page.viewportSize()))
+
         image = QImage(self.page.viewportSize(), format)
         painter = QPainter(image)
 

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -341,7 +341,9 @@ class Ghost(object):
         ):
             try:
                 os.environ['DISPLAY'] = ':99'
-                Ghost.xvfb = subprocess.Popen(['Xvfb', ':99'])
+                process = ['Xvfb', ':99', '-pixdepths', '32']
+                FNULL = open(os.devnull, 'w')
+                Ghost.xvfb = subprocess.Popen(process, stdout=FNULL, stderr=subprocess.STDOUT)
             except OSError:
                 raise Error('Xvfb is required to a ghost run outside ' +
                             'an X instance')


### PR DESCRIPTION
The following comment may be related to this issue.
// Assume that somewhere along the line, someone will do width * height * 4
// with signed numbers. If the maximum value is 2**31, then 2**31 / 4 =
// 2**29 and floor(sqrt(2**29)) = 23170.
https://github.com/adobe/chromium/blob/master/content/browser/renderer_host/backing_store_skia.cc
