### PR TITLE
prevent "Server is already active" error message

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -358,9 +358,17 @@ class Ghost(object):
                     '\tIf this server is no longer running, ' \
                     'remove /tmp/.X99-lock\n' \
                     '\tand start again.\n\n'
+                if PY3:
+                    # in python3, stderr has weirdly mis-formatted content
+                    expected_error_msg_py3 = repr(bytes(expected_error_msg,
+                                                        encoding='utf-8'))
+                else:
+                    expected_error_msg_py3 = None
 
-                error_output = Ghost.xvfb.stderr.read()
-                if error_output and error_output != expected_error_msg:
+                error_output = str(Ghost.xvfb.stderr.read())
+                if error_output != expected_error_msg \
+                        and (not PY3
+                             or error_output != expected_error_msg_py3):
                     raise Error(error_output)
             except OSError:
                 raise Error('Xvfb is required to a ghost run outside ' +

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -295,6 +295,10 @@ class Ghost(object):
     _prompt_expected = None
     _upload_file = None
     _app = None
+    display = None
+    manager = None
+    page = None
+    main_frame = None
 
     def __init__(
         self,
@@ -688,10 +692,14 @@ class Ghost(object):
         """Exits application and related."""
         if self.display:
             self.webview.close()
-        Ghost._app.quit()
-        del self.manager
-        del self.page
-        del self.main_frame
+        if Ghost._app:
+            Ghost._app.quit()
+        if self.manager:
+            del self.manager
+        if self.page:
+            del self.page
+        if self.main_frame:
+            del self.main_frame
         if hasattr(self, 'xvfb'):
             self.xvfb.terminate()
 


### PR DESCRIPTION
Two bug fixes:
1. There's a completely useless error message when starting Xvfb even though it's already running. This problem can both occur when Ghost isn't exited properly, or when multiple instances of Ghost are running, using the same Xvfb instance.
This change detects that very specific error message and doesn't write it to stderr. If a different error message occurs, Ghost doesn't just output it to stderr, but raise an exception.
This should prevent an error message people see unnecessarily while strengthening error handling in case there's a bigger problem with Xvfb.
Python3-specific, I had to work around the issue of stderr output from subprocess.Popen being misformatted (as the repr() of a bytes object). This is done in a way that once/if that bug is fixed, it'll still work.
1. If an exception is thrown during initialization of Ghost, Ghost can fail uncontrolled in the exit() function, which is called by **del**()

Feedback/change requests more than welcome!
