### PR TITLE
fixed a typo, changed `tornado` to `flask`

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@ with Ghost.confirm(False):
                 <article>
                     <h1 id="wsgi"><a href="#wsgi">WSGI apps</a></h1>
                     <p>Requirements:</p>
-                    <pre>pip install tornado</pre>
+                    <pre>pip install flask</pre>
                     <p>ghost.py provides a simple GhostTestCase that deals with WSGI applications:</p>
                     <code class="python">import unittest
 from flask import Flask


### PR DESCRIPTION
I think you mean installing Flask instead of Tornado. 

Originally found by /u/RisingStar on [/r/python](http://www.reddit.com/r/Python/comments/3828ss/ghostpy_a_webkit_web_client_written_in_python/crrxjgw)