### PR TITLE
Correct the PY3 test

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import sys
-PY3 = sys.version > '3'
+PY3 = sys.version_info.major >= 3
 import os
 import time
 import uuid


### PR DESCRIPTION
```python
PY3 = sys.version > '3'  # is True on Python 2.7.10 on Mac OS X
```