### PR TITLE
add a method for directly rendering HTML string

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ ghost.py is a webkit web client written in python::
 Installation
 ------------
 
-ghost.py requires either PySide_ (prefered) or PyQt_ Qt_ bindings::
+ghost.py requires either PySide_ (preferred) or PyQt_ Qt_ bindings::
 
     pip install pyside
     pip install ghost.py --pre

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1047,7 +1047,7 @@ class Ghost(object):
                 res, resources = self.click(selector)
                 Ghost._upload_file = None
         else:
-            raise Error('unsuported field tag')
+            raise Error('unsupported field tag')
 
         for event in ['input', 'change']:
             self.fire(selector, event);

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -15,7 +15,7 @@ except ImportError:
 from contextlib import contextmanager
 from .logger import configure
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 if PY3:
     unicode = str

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -867,6 +867,22 @@ class Ghost(object):
         if wait:
             return self.wait_for_page_loaded(timeout=timeout)
 
+    def render_html(
+        self,
+        html,
+        base_url=None,
+        default_popup_response=None,
+    ):
+        self.logger.info('Rendering %s' % base_url if base_url else 'html')
+        if base_url:
+            base_url = QUrl(base_url)
+        self.main_frame.setHtml(html, base_url)
+        self.loaded = True
+
+        if default_popup_response is not None:
+            self._prompt_expected = default_popup_response
+            self._confirm_expected = default_popup_response
+
     def scroll_to_anchor(self, anchor):
         self.main_frame.scrollToAnchor(anchor)
 

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -603,10 +603,14 @@ class Ghost(object):
         self.webview.print_(printer)
 
     @can_load_page
-    def click(self, selector):
+    def click(self, selector, btn=0):
         """Click the targeted element.
 
         :param selector: A CSS3 selector to targeted element.
+        :param btn: The number of mouse button.
+            0 - left button,
+            1 - middle button,
+            2 - right button
         """
         if not self.exists(selector):
             raise Error("Can't find element to click")
@@ -615,10 +619,10 @@ class Ghost(object):
                 var element = document.querySelector(%s);
                 var evt = document.createEvent("MouseEvents");
                 evt.initMouseEvent("click", true, true, window, 1, 1, 1, 1, 1,
-                    false, false, false, false, 0, element);
+                    false, false, false, false, %s, element);
                 return element.dispatchEvent(evt);
             })();
-        """ % repr(selector))
+        """ % (repr(selector), str(btn)))
 
     @contextmanager
     def confirm(self, confirm=True):


### PR DESCRIPTION
I think it is a bit troublesome to render HTML string.
This change adds `render_html` method to easily render HTML string.