### PR TITLE
Add the possibility to create a filter for the urls requested

### DIFF
--- a/tests/run.py
+++ b/tests/run.py
@@ -446,6 +446,15 @@ class GhostTest(GhostTestCase):
             new_agent,
         )
 
+    def test_exclude_regex(self):
+        session = self.ghost.start(exclude="\.(jpg|css)")
+        page, resources = session.open(base_url)
+        url_loaded = [r.url for r in resources]
+        self.assertFalse(
+            "%sstatic/styles.css" % base_url in url_loaded)
+        self.assertFalse(
+            "%sstatic/blackhat.jpg" % base_url in url_loaded)
+        session.exit()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
You can pass a function pointer to the validate_req_fct parameter at the Initialisation of the Session object
This function will be called at each request, with the url concerned (as a string object)
If the return value of this function is True, the request is aborted.
Close #252 

Exemple:
```python
    def test(url):
        if url.endswith('.css'):
            return True
        return False

    session = ghost.start(validate_req_fct=test)
    session.open('http://www.thisisatest.com')