### PR TITLE
Fix for segfault when closing Session

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -717,7 +717,7 @@ class Session(object):
         del self.cookie_jar
         del self.manager
         del self.main_frame
-        del self.page
+        self.page.deleteLater()
         self.sleep()
 
     @can_load_page


### PR DESCRIPTION
Following segfault occured at del self.page in Session.exit.

```
    2015-09-20T07:15:51.352Z [INFO    ] Ghost<89e47d28-7bc6-484e-ab2d-de65a79d6203>: Closing session
    [Thread 0x7fffe1944700 (LWP 4273) exited]

    Program received signal SIGSEGV, Segmentation fault.
    0x0000000000000000 in ?? ()
    (gdb) trace 
    Tracepoint 1 at 0x0
    (gdb) backtrace 
    #0  0x0000000000000000 in ?? ()
    #1  0x00007ffff446cb04 in QObject::disconnect(QObject const*, char const*, QObject const*, char const*) () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
    #2  0x00007fffee2894ee in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #3  0x00007fffee28954f in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #4  0x00007fffee2896b8 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #5  0x00007fffee2896fe in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #6  0x00007fffee2866e9 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #7  0x00007fffee090a55 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #8  0x00007fffee09b457 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #9  0x00007fffee090f7d in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #10 0x00007fffee090da0 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #11 0x00007fffee05b3d6 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #12 0x00007fffee05b71a in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #13 0x00007fffee0677c8 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #14 0x00007fffee06b988 in ?? () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #15 0x00007fffedce450b in QWebPage::~QWebPage() () from /usr/lib/x86_64-linux-gnu/libQtWebKit.so.4
    #16 0x00007fffeefcce45 in QWebPageWrapper::~QWebPageWrapper() () from /home/user/venv/local/lib/python2.7/site-packages/PySide/QtWebKit.so
    #17 0x00007ffff47bf47e in SbkDeallocWrapperCommon () from /home/user/venv/local/lib/python2.7/site-packages/PySide/libshiboken-python2.7.so.1.2
    #18 0x00000000005020b8 in ?? ()
    #19 0x000000000057a613 in PyDict_DelItem ()
    #20 0x000000000043a61e in _PyObject_GenericSetAttrWithDict ()
    #21 0x000000000043a78d in PyObject_SetAttr ()
    #22 0x000000000054ef46 in PyEval_EvalFrameEx ()
    #23 0x000000000054c272 in PyEval_EvalFrameEx ()
    #24 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #25 0x0000000000577ab0 in ?? ()
    ---Type <return> to continue, or q <return> to quit---
    #26 0x00000000004d91b6 in PyObject_Call ()
    #27 0x00000000004c91fa in ?? ()
    #28 0x00000000004d91b6 in PyObject_Call ()
    #29 0x00000000004d9e1b in PyObject_CallFunctionObjArgs ()
    #30 0x000000000054dc15 in PyEval_EvalFrameEx ()
    #31 0x0000000000575d92 in PyEval_EvalCodeEx ()
    #32 0x00000000004c1352 in PyRun_SimpleFileExFlags ()
    #33 0x00000000004c754f in Py_Main ()
    #34 0x00007ffff68cd76d in __libc_start_main () from /lib/x86_64-linux-gnu/libc.so.6
    #35 0x000000000041ba41 in _start ()
    (gdb) 
```

Problem was resolved by replacing del self.page to self.page.deleteLater(). 
Refference: http://doc.qt.io/qt-4.8/qobject.html#dtor.QObject
