### PR TITLE
Added logger to NetworkAccessManager

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -229,8 +229,9 @@ class NetworkAccessManager(QNetworkAccessManager):
     :param exclude_regex: A regex use to determine wich url exclude
         when sending a request
     """
-    def __init__(self, exclude_regex=None, *args, **kwargs):
+    def __init__(self, exclude_regex=None, logger=None, *args, **kwargs):
         self._regex = re.compile(exclude_regex) if exclude_regex else None
+	self.logger = logger
         super(self.__class__, self).__init__(*args, **kwargs)
 
     def createRequest(self, operation, request, data):
@@ -245,9 +246,12 @@ class NetworkAccessManager(QNetworkAccessManager):
             data
         )
         reply.readyRead.connect(lambda reply=reply: replyReadyRead(reply))
+	reply.error.connect(self._reply_error)
         time.sleep(0.001)
         return reply
 
+    def _reply_error(self, arg):
+        self.logger.error("Reply error: %s" % arg)
 
 class Ghost(object):
     """`Ghost` manages a Qt application.
@@ -394,7 +398,7 @@ class Session(object):
 
         if network_access_manager_class is not None:
             self.page.setNetworkAccessManager(
-                network_access_manager_class(exclude_regex=exclude))
+                network_access_manager_class(exclude_regex=exclude, logger=self.logger))
 
         QtWebKit.QWebSettings.setMaximumPagesInCache(0)
         QtWebKit.QWebSettings.setObjectCacheCapacities(0, 0, 0)


### PR DESCRIPTION
Can check why request failed as follows:

```
2015-09-20T14:32:19.324Z [INFO    ] Ghost<24fb0865-15ea-4376-9811-00e070d647bf>: Starting new session
2015-09-20T14:32:19.446Z [INFO    ] Ghost<24fb0865-15ea-4376-9811-00e070d647bf>: Opening http://example
2015-09-20T14:32:19.508Z [ERROR   ] Ghost<24fb0865-15ea-4376-9811-00e070d647bf>: Reply error: PySide.QtNetwork.QNetworkReply.NetworkError.HostNotFoundError
2015-09-20T14:32:19.613Z [INFO    ] Ghost<24fb0865-15ea-4376-9811-00e070d647bf>: Page loaded 
2015-09-20T14:32:19.623Z [INFO    ] Ghost<24fb0865-15ea-4376-9811-00e070d647bf>: Closing session
```
