### PR TITLE
Modified unsupported conntent donwload.

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -197,7 +197,7 @@ class HttpResource(object):
         self.http_status = reply.attribute(
             QNetworkRequest.HttpStatusCodeAttribute)
         self.session.logger.info(
-            "Resource loaded: %s %s" % (self.url, self.http_status)
+            "Resource loaded: %s %s %s" % (self.url, self.http_status, len(self.content))
         )
         self.headers = {}
         for header in reply.rawHeaderList():
@@ -229,8 +229,9 @@ class NetworkAccessManager(QNetworkAccessManager):
     :param exclude_regex: A regex use to determine wich url exclude
         when sending a request
     """
-    def __init__(self, exclude_regex=None, *args, **kwargs):
+    def __init__(self, exclude_regex=None, logger=None, *args, **kwargs):
         self._regex = re.compile(exclude_regex) if exclude_regex else None
+        self.logger = logger
         super(self.__class__, self).__init__(*args, **kwargs)
 
     def createRequest(self, operation, request, data):
@@ -245,8 +246,18 @@ class NetworkAccessManager(QNetworkAccessManager):
             data
         )
         reply.readyRead.connect(lambda reply=reply: replyReadyRead(reply))
+        reply.error.connect(self._reply_error)
+        if self.logger.isEnabledFor(logging.DEBUG):
+            reply.downloadProgress.connect(self._reply_download_progress)
         time.sleep(0.001)
         return reply
+
+    def _reply_error(self, arg):
+        self.logger.error("Reply error: %s" % arg)
+
+    def _reply_download_progress(self, sent, total):
+        self.logger.debug("Download Progress: %s sent / %s total" % (sent, total))
+        time.sleep(0.1)
 
 
 class Ghost(object):
@@ -394,7 +405,7 @@ class Session(object):
 
         if network_access_manager_class is not None:
             self.page.setNetworkAccessManager(
-                network_access_manager_class(exclude_regex=exclude))
+                network_access_manager_class(exclude_regex=exclude, logger=self.logger))
 
         QtWebKit.QWebSettings.setMaximumPagesInCache(0)
         QtWebKit.QWebSettings.setObjectCacheCapacities(0, 0, 0)
@@ -1194,6 +1205,7 @@ class Session(object):
         """
         self.wait_for(lambda: self.loaded,
                       'Unable to load requested page', timeout)
+        self.sleep(1)
         resources = self._release_last_resources()
         page = None
 
@@ -1263,7 +1275,6 @@ class Session(object):
         """Called back when page is loaded.
         """
         self.loaded = True
-        self.sleep()
 
     def _page_load_started(self):
         """Called back when page load started.
@@ -1276,6 +1287,7 @@ class Session(object):
         :return: The released resources.
         """
         last_resources = self.http_resources
+        self.logger.info(str(len(last_resources)) + " resources loaded.")
         self.http_resources = []
         return last_resources
 
@@ -1306,9 +1318,13 @@ class Session(object):
         self.logger.info("Unsupported content %s" % (
             str(reply.url()),
         ))
-
+        reply.readyRead.disconnect(replyReadyRead(reply))
+        if hasattr(reply, 'data'):
+                reply.data = ''
         reply.readyRead.connect(
             lambda reply=reply: self._reply_download_content(reply))
+        while reply.isRunning():
+            self.sleep()
 
     def _reply_download_content(self, reply):
         """Adds an HttpResource object to http_resources with unsupported
@@ -1317,11 +1333,14 @@ class Session(object):
         :param reply: The QNetworkReply object.
         """
         if reply.attribute(QNetworkRequest.HttpStatusCodeAttribute):
+            reply.data = reply.data + reply.readAll()
+            """
             self.http_resources.append(HttpResource(
                 self,
                 reply,
                 reply.readAll(),
             ))
+            """
 
     def _on_manager_ssl_errors(self, reply, errors):
         url = unicode(reply.url().toString())


### PR DESCRIPTION
Fixed some download problem:
- Page loaded
  -  page_loaded signal would be sent before the loading of the resources is finished.  Need some sleep after the page has been loaded.
- Unsupported content download
  - Default reply.readyRead causes duplicate reading of reply, so it should be disconnected.
    Also, reply.data should be cleared.
  - _reply_download_content creates a resource when readyRead, this causes spliting one content to multiple resources.
