### PR TITLE
Fix NetworkAccessManager's __init__

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -231,7 +231,7 @@ class NetworkAccessManager(QNetworkAccessManager):
     """
     def __init__(self, exclude_regex=None, *args, **kwargs):
         self._regex = re.compile(exclude_regex) if exclude_regex else None
-        super(self.__class__, self).__init__(*args, **kwargs)
+        super(NetworkAccessManager, self).__init__(*args, **kwargs)
 
     def createRequest(self, operation, request, data):
         if self._regex and self._regex.findall(str(request.url().toString())):


### PR DESCRIPTION
Right now NetworkAccessManager is calling super with super(self.**class**, self), however this means when you try to subclass it and call super yourself you land in infinite recurrsion on NetworkAccessManager's **init**. 
For a class meant to be subclassed that's bad news bears.
