### PR TITLE
Fix image not found Error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ OSX:
     brew install qt
     mkvirtualenv foo
     pip install -U pip  # make sure pip is current
-    pip install PySide
+    pip install PySide==1.2.2
     pyside_postinstall.py -install
     pip install Ghost.py
 


### PR DESCRIPTION
I met the same problem as  describe in #269 and #268 .

when install PySide by pip, we better use

```
pip install PySide==1.2.2
```

then we can do:

```
pyside_postinstall.py -install
```

'cuz the `pyside_postinstall.py` can not be found if users install the newest version: PySide==1.2.4

as [PySide 1.2.4 doc](https://pypi.python.org/pypi/PySide/1.2.4) said:

> On Linux and MacOS systems there is no more need to call the post-install script
