### PR TITLE
Update ghost.py

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -191,7 +191,7 @@ class HttpResource(object):
         self.url = reply.url().toString()
         self.content = content
         try:
-            self.content = unicode(content)
+            self.content = unicode(content, encoding='utf-8')
         except UnicodeDecodeError:
             self.content = content
         self.http_status = reply.attribute(


### PR DESCRIPTION
content is bytearray
https://docs.python.org/3.4/library/stdtypes.html#str

"If at least one of encoding or errors is given, object should be a bytes-like object (e.g. bytes or bytearray). In this case, if object is a bytes (or bytearray) object, then str(bytes, encoding, errors) is equivalent to bytes.decode(encoding, errors). Otherwise, the bytes object underlying the buffer object is obtained before calling bytes.decode()."
