### PR TITLE
Page loaded before all requests done

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include README.rst *.py
 include ghost/ghost.py
 include ghost/test.py
 include ghost/ext/django/test.py
+include tox.ini
 recursive-include docs *
 recursive-exclude docs *.pyc
 recursive-exclude docs *.pyo

--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,7 @@ OSX:
     brew install qt
     mkvirtualenv foo
     pip install -U pip  # make sure pip is current
-    pip install PySide
-    pyside_postinstall.py -install
+    pip install "PySide>=1.2.4"
     pip install Ghost.py
 
 

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -298,6 +298,7 @@ class Ghost(object):
         self.defaults = defaults or dict()
 
     def exit(self):
+        self.logger.info('Stopping QT application')
         self._app.quit()
         if hasattr(self, 'xvfb'):
             self.xvfb.terminate()

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -51,8 +51,10 @@ if PY3:
     long = int
     basestring = str
 
-default_user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.2 " +\
-    "(KHTML, like Gecko) Chrome/15.0.874.121 Safari/535.2"
+default_user_agent = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/57.0.2987.133 Safari/537.36"
+)
 
 logger = logging.getLogger('ghost')
 logger.addHandler(logging.NullHandler())

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1,45 +1,48 @@
 # -*- coding: utf-8 -*-
-import sys
-import os
-import time
-import uuid
 import codecs
 import logging
+import os
 import re
+import sys
+import time
+import uuid
+from contextlib import contextmanager
 from functools import wraps
+
+from xvfbwrapper import Xvfb
+
+from .bindings import (
+    QApplication,
+    QByteArray,
+    QDateTime,
+    QImage,
+    QNetworkAccessManager,
+    QNetworkCookie,
+    QNetworkCookieJar,
+    QNetworkProxy,
+    QNetworkRequest,
+    QPainter,
+    QPrinter,
+    QRegion,
+    QSize,
+    QSsl,
+    QSslConfiguration,
+    QtCore,
+    QtCriticalMsg,
+    QtDebugMsg,
+    QtFatalMsg,
+    QtNetwork,
+    QtWarningMsg,
+    QtWebKit,
+    QUrl,
+    binding,
+    qInstallMsgHandler,
+)
+
 try:
     from cookielib import Cookie, LWPCookieJar
 except ImportError:
     from http.cookiejar import Cookie, LWPCookieJar
-from contextlib import contextmanager
-from .bindings import (
-    binding,
-    QtCore,
-    QSize,
-    QByteArray,
-    QUrl,
-    QDateTime,
-    QtCriticalMsg,
-    QtDebugMsg,
-    QtFatalMsg,
-    QtWarningMsg,
-    qInstallMsgHandler,
-    QApplication,
-    QImage,
-    QPainter,
-    QPrinter,
-    QRegion,
-    QtNetwork,
-    QNetworkRequest,
-    QNetworkAccessManager,
-    QNetworkCookieJar,
-    QNetworkProxy,
-    QNetworkCookie,
-    QSslConfiguration,
-    QSsl,
-    QtWebKit,
-)
-from xvfbwrapper import Xvfb
 
 __version__ = "0.2.3"
 

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -332,8 +332,6 @@ class NetworkAccessManager(QNetworkAccessManager):
 
         self.logger.debug('Registring reply for %s', reply.url().toString())
         self._registry[id(reply)] = reply
-
-        time.sleep(0.001)
         return reply
 
     def _reply_finished_callback(self, reply):

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -242,6 +242,12 @@ def reply_ready_read(reply):
     reply.readAll()
 
 
+def reply_download_progress(reply, received, total):
+    """Log `reply` download progress."""
+    reply.manager().logger.debug('Downloading content of %s: %s of %s',
+                                 reply.url().toString(), received, total)
+
+
 class NetworkAccessManager(QNetworkAccessManager):
     """Subclass QNetworkAccessManager to always cache the reply content
 
@@ -264,12 +270,8 @@ class NetworkAccessManager(QNetworkAccessManager):
             request,
             data
         )
-        reply.readyRead.connect(lambda reply=reply: reply_ready_peek(reply))
-        reply.downloadProgress.connect(
-            lambda received, total:
-            self.logger.debug('Downloading content of %s: %s of %s',
-                              reply.url(), received, total)
-        )
+        reply.readyRead.connect(partial(reply_ready_peek, reply))
+        reply.downloadProgress.connect(partial(reply_download_progress, reply))
         time.sleep(0.001)
         return reply
 

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1266,6 +1266,8 @@ class Session(object):
         started_at = time.time()
         while not condition():
             if time.time() > (started_at + timeout):
+                self.logger.debug('Timeout with %d requests still in flight',
+                                  self.manager.requests)
                 raise TimeoutError(timeout_message)
             self.sleep(value=timeout / 10)
             if self.wait_callback is not None:

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1274,8 +1274,7 @@ class Session(object):
 
         if reply.attribute(QNetworkRequest.HttpStatusCodeAttribute):
             self.logger.debug("[%s] bytesAvailable()= %s",
-                              str(reply.url()),
-                              reply.bytesAvailable())
+                              reply.url().toString(), reply.bytesAvailable())
 
             try:
                 content = reply.data
@@ -1289,8 +1288,7 @@ class Session(object):
             ))
 
     def _unsupported_content(self, reply):
-        self.logger.info("Unsupported content %s",
-                         str(reply.url()))
+        self.logger.info("Unsupported content %s", reply.url().toString())
 
         reply.readyRead.connect(
             lambda reply=reply: self._reply_download_content(reply))
@@ -1309,11 +1307,11 @@ class Session(object):
             ))
 
     def _on_manager_ssl_errors(self, reply, errors):
-        url = unicode(reply.url().toString())
         if self.ignore_ssl_errors:
             reply.ignoreSslErrors()
         else:
-            self.logger.warning('SSL certificate error: %s', url)
+            self.logger.warning('SSL certificate error: %s',
+                                reply.url().toString())
 
     def __enter__(self):
         return self

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1292,22 +1292,6 @@ class Session(object):
         self.logger.info("Unsupported content %s",
                          str(reply.url()))
 
-        reply.readyRead.connect(
-            lambda reply=reply: self._reply_download_content(reply))
-
-    def _reply_download_content(self, reply):
-        """Adds an HttpResource object to http_resources with unsupported
-        content.
-
-        :param reply: The QNetworkReply object.
-        """
-        if reply.attribute(QNetworkRequest.HttpStatusCodeAttribute):
-            self.http_resources.append(HttpResource(
-                self,
-                reply,
-                reply.readAll(),
-            ))
-
     def _on_manager_ssl_errors(self, reply, errors):
         url = unicode(reply.url().toString())
         if self.ignore_ssl_errors:

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -277,7 +277,7 @@ class Ghost(object):
             'DISPLAY' not in os.environ
         ):
             try:
-                self.logger.debug('Using Xvfb graphics.')
+                self.logger.debug('Using Xvfb display server')
                 self.xvfb = Xvfb(
                     width=800,
                     height=600,
@@ -288,7 +288,8 @@ class Ghost(object):
                 raise Error('Xvfb is required to a ghost run outside ' +
                             'an X instance')
         else:
-            self.logger.debug('Using X11 server.')
+            self.logger.debug('Using X11 display server %s',
+                              os.environ['DISPLAY'])
 
         self.logger.info('Initializing QT application')
         Ghost._app = QApplication.instance() or QApplication(['ghost'])
@@ -304,7 +305,7 @@ class Ghost(object):
         self.logger.info('Stopping QT application')
         self._app.quit()
         if hasattr(self, 'xvfb'):
-            self.logger.debug('Terminating xvfb.')
+            self.logger.debug('Terminating Xvfb display server')
             self.xvfb.stop()
 
     def start(self, **kwargs):

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -269,6 +269,12 @@ def reply_download_progress(reply, received, total):
                                  reply.url().toString(), received, total)
 
 
+def _reply_error_callback(reply, error_code):
+    """Log an error message on QtNetworkReply error."""
+    reply.manager().logger.error('Reply for %s encountered an error: %s',
+                                 reply.url().toString(), reply.errorString())
+
+
 class NetworkAccessManager(QNetworkAccessManager):
     """Subclass QNetworkAccessManager to always cache the reply content
 
@@ -301,6 +307,7 @@ class NetworkAccessManager(QNetworkAccessManager):
         )
         reply.readyRead.connect(partial(reply_ready_peek, reply))
         reply.downloadProgress.connect(partial(reply_download_progress, reply))
+        reply.error.connect(partial(_reply_error_callback, reply))
 
         self.logger.debug('Registring reply for %s', reply.url().toString())
         self._registry[id(reply)] = reply

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -311,7 +311,13 @@ class NetworkAccessManager(QNetworkAccessManager):
     def _reply_finished_callback(self, reply):
         """Unregister a complete QNetworkReply."""
         self.logger.debug('Reply for %s complete', reply.url().toString())
-        self._registry.pop(id(reply))
+        try:
+            self._registry.pop(id(reply))
+        except KeyError:
+            # Workaround for QtWebkit bug #82506
+            # https://bugs.webkit.org/show_bug.cgi?format=multiple&id=82506
+            self.logger.debug('Reply was not in registry,'
+                              'maybe webkit bug #82506')
 
     @property
     def requests(self):

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -755,7 +755,7 @@ class Session(object):
         """Exits all Qt widgets."""
         self.logger.info("Closing session")
         self.page.deleteLater()
-        self.sleep()
+        self.ghost._app.processEvents()
         del self.webview
         del self.cookie_jar
         del self.manager
@@ -1192,7 +1192,7 @@ class Session(object):
         """
         self.logger.debug('Showing webview')
         self.webview.show()
-        self.sleep()
+        self.ghost._app.processEvents()
 
     def sleep(self, value=0.1):
         started_at = time.time()
@@ -1304,7 +1304,7 @@ class Session(object):
         """Called back when page is loaded.
         """
         self.loaded = True
-        self.sleep()
+        self.ghost._app.processEvents()
 
     def _page_load_started(self):
         """Called back when page load started.

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -277,6 +277,7 @@ class Ghost(object):
             'DISPLAY' not in os.environ
         ):
             try:
+                self.logger.debug('Using Xvfb graphics.')
                 self.xvfb = Xvfb(
                     width=800,
                     height=600,
@@ -286,6 +287,8 @@ class Ghost(object):
             except OSError:
                 raise Error('Xvfb is required to a ghost run outside ' +
                             'an X instance')
+        else:
+            self.logger.debug('Using X11 server.')
 
         self.logger.info('Initializing QT application')
         Ghost._app = QApplication.instance() or QApplication(['ghost'])
@@ -301,6 +304,7 @@ class Ghost(object):
         self.logger.info('Stopping QT application')
         self._app.quit()
         if hasattr(self, 'xvfb'):
+            self.logger.debug('Terminating xvfb.')
             self.xvfb.stop()
 
     def start(self, **kwargs):

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -282,11 +282,12 @@ class NetworkAccessManager(QNetworkAccessManager):
 
     def createRequest(self, operation, request, data):
         if self._regex and self._regex.findall(str(request.url().toString())):
-            return QNetworkAccessManager.createRequest(
-                self, QNetworkAccessManager.GetOperation,
-                QNetworkRequest(QUrl()))
-        reply = QNetworkAccessManager.createRequest(
-            self,
+            return super(NetworkAccessManager, self).createRequest(
+                QNetworkAccessManager.GetOperation,
+                QNetworkRequest(QUrl())
+            )
+
+        reply = super(NetworkAccessManager, self).createRequest(
             operation,
             request,
             data

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -5,7 +5,6 @@ import time
 import uuid
 import codecs
 import logging
-import subprocess
 import re
 from functools import wraps
 try:
@@ -40,6 +39,7 @@ from .bindings import (
     QSsl,
     QtWebKit,
 )
+from xvfbwrapper import Xvfb
 
 __version__ = "0.2.3"
 
@@ -277,14 +277,12 @@ class Ghost(object):
             'DISPLAY' not in os.environ
         ):
             try:
-                os.environ['DISPLAY'] = ':99'
-                process = ['Xvfb', ':99', '-pixdepths', '32']
-                FNULL = open(os.devnull, 'w')
-                self.xvfb = subprocess.Popen(
-                    process,
-                    stdout=FNULL,
-                    stderr=subprocess.STDOUT,
+                self.xvfb = Xvfb(
+                    width=800,
+                    height=600,
                 )
+                self.xvfb.start()
+
             except OSError:
                 raise Error('Xvfb is required to a ghost run outside ' +
                             'an X instance')
@@ -303,7 +301,7 @@ class Ghost(object):
         self.logger.info('Stopping QT application')
         self._app.quit()
         if hasattr(self, 'xvfb'):
-            self.xvfb.terminate()
+            self.xvfb.stop()
 
     def start(self, **kwargs):
         """Starts a new `Session`."""

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -7,7 +7,7 @@ import codecs
 import logging
 import subprocess
 import re
-from functools import wraps
+from functools import partial, wraps
 try:
     from cookielib import Cookie, LWPCookieJar
 except ImportError:
@@ -227,6 +227,14 @@ def reply_ready_peek(reply):
         reply.data = ''
 
     reply.data += reply.peek(reply.bytesAvailable())
+
+
+def reply_ready_read(reply):
+    """Consume data from `reply` buffer.
+
+    :param reply: QNetworkReply object.
+    """
+    reply.readAll()
 
 
 class NetworkAccessManager(QNetworkAccessManager):
@@ -1304,6 +1312,10 @@ class Session(object):
     def _unsupported_content(self, reply):
         self.logger.info("Unsupported content %s",
                          str(reply.url()))
+        # reply went though reply_read_peek already, consume buffer to avoid
+        # duplication on next "ready" signal handling and connect callback
+        reply_ready_read(reply)
+        reply.readyRead.connect(partial(reply_ready_read, reply))
 
     def _on_manager_ssl_errors(self, reply, errors):
         url = unicode(reply.url().toString())

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -313,10 +313,10 @@ class Ghost(object):
         plugin_path=['/usr/lib/mozilla/plugins', ],
         defaults=None,
     ):
-        if not binding:
-            raise Exception("Ghost.py requires PySide or PyQt4")
-
         self.logger = logger.getChild('application')
+
+        if not binding:
+            raise RuntimeError("Ghost.py requires PySide or PyQt4")
 
         if (
             sys.platform.startswith('linux') and
@@ -349,7 +349,8 @@ class Ghost(object):
 
     def exit(self):
         self.logger.info('Stopping QT application')
-        self._app.quit()
+        if self._app:
+            self._app.quit()
         if hasattr(self, 'xvfb'):
             self.logger.debug('Terminating Xvfb display server')
             self.xvfb.stop()

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -1198,7 +1198,7 @@ class Session(object):
         started_at = time.time()
 
         while time.time() <= (started_at + value):
-            time.sleep(0.01)
+            time.sleep(value / 10)
             self.ghost._app.processEvents()
 
     def wait_for(self, condition, timeout_message, timeout=None):
@@ -1213,7 +1213,7 @@ class Session(object):
         while not condition():
             if time.time() > (started_at + timeout):
                 raise TimeoutError(timeout_message)
-            self.sleep()
+            self.sleep(value=timeout / 10)
             if self.wait_callback is not None:
                 self.wait_callback()
 

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -216,7 +216,13 @@ class HttpResource(object):
         self._reply = reply
 
 
-def replyReadyRead(reply):
+def reply_ready_peek(reply):
+    """Copy available bytes to `reply` data attribute.
+
+    .. note:: Does not consume the `reply` buffer!
+
+    :param reply: QNetworkReply object.
+    """
     if not hasattr(reply, 'data'):
         reply.data = ''
 
@@ -245,7 +251,7 @@ class NetworkAccessManager(QNetworkAccessManager):
             request,
             data
         )
-        reply.readyRead.connect(lambda reply=reply: replyReadyRead(reply))
+        reply.readyRead.connect(lambda reply=reply: reply_ready_peek(reply))
         reply.downloadProgress.connect(
             lambda received, total:
             self.logger.debug('Downloading content of %s: %s of %s',

--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -313,10 +313,10 @@ class Ghost(object):
         plugin_path=['/usr/lib/mozilla/plugins', ],
         defaults=None,
     ):
-        self.logger = logger.getChild('application')
-
         if not binding:
             raise RuntimeError("Ghost.py requires PySide or PyQt4")
+
+        self.logger = logger.getChild('application')
 
         if (
             sys.platform.startswith('linux') and
@@ -348,8 +348,8 @@ class Ghost(object):
         self.defaults = defaults or dict()
 
     def exit(self):
-        self.logger.info('Stopping QT application')
         if self._app:
+            self.logger.info('Stopping QT application')
             self._app.quit()
         if hasattr(self, 'xvfb'):
             self.logger.debug('Terminating Xvfb display server')

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,11 @@ all_files  = 1
 [upload_sphinx]
 upload-dir = docs/build/html
 
+[isort]
+combine_as_imports = True
+include_trailing_comma = True
+multi_line_output = 3
+
 [nosetests]
 verbosity = 2
 tests = tests/run.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,12 @@ upload-dir = docs/build/html
 [nosetests]
 verbosity = 2
 tests = tests/run.py
+cover-package = ghost
+with-coverage = 1
+cover-branches = 1
+cover-erase = 1
+cover-inclusive = 1
+
+[coverage:run]
+branch = True
+omit = tests/run.py

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,9 @@ setup(
     test_suite='tests.run',
     zip_safe=False,
     platforms='any',
+    install_requires=[
+        'xvfbwrapper ~=0.2.8',
+    ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -5,20 +5,43 @@ Ghost.py
 Webkit based webclient.
 
 """
-from setuptools import setup, find_packages
-from ghost import __version__
+
+import io
+import os
+import re
+
+from setuptools import find_packages, setup
+
+MODULE_NAME = 'ghost'
+
+
+def find_file(*path_components):
+    """Builds path from arguments."""
+    return os.path.join(os.path.dirname(__file__), *path_components)
+
+
+def get_version():
+    """Reads package version number from module."""
+    with io.open(
+        find_file(MODULE_NAME, 'ghost.py'),
+        encoding='utf8'
+    ) as init:
+        for line in init.readlines():
+            res = re.match(r'^__version__ = [\'"](.*)[\'"]$', line)
+            if res:
+                return res.group(1)
 
 
 setup(
     name='Ghost.py',
-    version=__version__,
+    version=get_version(),
     url='https://github.com/jeanphix/Ghost.py',
     license='mit',
     author='Jean-Philippe Serafin',
     author_email='serafinjp@gmail.com',
     description='Webkit based webclient.',
     long_description=__doc__,
-    data_files=[('ghost', ['README.rst',])],
+    data_files=[(MODULE_NAME, ['README.rst',])],
     packages=find_packages(),
     include_package_data=True,
     tests_require=['Flask'],

--- a/tests/app.py
+++ b/tests/app.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import io
 import os
 import sys
 
@@ -15,8 +16,6 @@ from flask import (
     url_for,
 )
 from werkzeug.datastructures import Headers
-
-PY3 = sys.version > '3'
 
 
 app = Flask(__name__)
@@ -121,10 +120,7 @@ def send_file():
     h.add('Content-type', 'application/octet-stream', charset='utf8')
     h.add('Content-disposition', 'attachment', filename='name.tar.gz')
     file_path = os.path.join(os.path.dirname(__file__), 'static', 'foo.tar.gz')
-    if PY3:
-        f = open(file_path, 'r', encoding='latin-1')
-    else:
-        f = open(file_path, 'r')
+    f = io.open(file_path, 'rb')
     return Response(f, headers=h)
 
 

--- a/tests/app.py
+++ b/tests/app.py
@@ -1,22 +1,20 @@
 # -*- coding: utf-8 -*-
-import sys
 import os
+import sys
 
 from flask import (
+    Flask,
+    Response,
     abort,
     flash,
-    Flask,
     jsonify,
     make_response,
     redirect,
     render_template,
     request,
-    Response,
     url_for,
 )
-
 from werkzeug.datastructures import Headers
-
 
 PY3 = sys.version > '3'
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -3,20 +3,23 @@
 
 from __future__ import absolute_import
 
-import sys
-import os
 import json
 import logging
+import os
+import sys
 import unittest
-try:
-    import cookielib
-except ImportError:
-    from http import cookiejar as cookielib
 
 from ghost import GhostTestCase
 from ghost.ghost import default_user_agent
 
 from .app import app
+
+try:
+    import cookielib
+except ImportError:
+    from http import cookiejar as cookielib
+
+
 
 
 PY3 = sys.version > '3'

--- a/tests/run.py
+++ b/tests/run.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 
+import io
 import json
 import logging
 import os
@@ -19,10 +20,6 @@ try:
 except ImportError:
     from http import cookiejar as cookielib
 
-
-
-
-PY3 = sys.version > '3'
 
 PORT = 5000
 
@@ -381,12 +378,8 @@ class GhostTest(GhostTestCase):
             'static',
             'foo.tar.gz',
         )
-        if PY3:
-            f = open(file_path, 'r', encoding='latin-1')
-        else:
-            f = open(file_path, 'r')
-        foo = f.read(1024)
-        f.close()
+        with io.open(file_path, 'rb') as f:
+            foo = f.read()
 
         self.assertEqual(resources[0].content, foo)
 

--- a/tests/run.py
+++ b/tests/run.py
@@ -58,14 +58,11 @@ class GhostTest(GhostTestCase):
 
     def test_extra_resource_content(self):
         page, resources = self.session.open(base_url)
-        self.assertIn('globals alert', resources[4].content)
+        self.assertIn(b'globals alert', resources[4].content)
 
     def test_extra_resource_binaries(self):
         page, resources = self.session.open(base_url)
-        self.assertEqual(
-            resources[5].content.__class__.__name__,
-            'QByteArray',
-        )
+        self.assertIsInstance(resources[5].content, bytes)
 
     def test_wait_for_selector(self):
         page, resources = self.session.open(base_url)
@@ -438,7 +435,7 @@ class GhostTest(GhostTestCase):
                 "%sdump" % base_url,
                 **kwargs
             )
-            data = json.loads(page.content)
+            data = json.loads(page.content.decode('utf-8'))
             return data['headers']['User-Agent']
 
         session = self.session

--- a/tox.ini
+++ b/tox.ini
@@ -19,5 +19,6 @@ passenv = DISPLAY
 deps =
     pyside: PySide
     nose
+    coverage
 commands =
     {envpython} ./setup.py nosetests {posargs}


### PR DESCRIPTION
I was trying to compute checksum of resources downloaded by Ghost.py but some sites stream their content. This is not a problem for regular web content but file that go through `unsupported_content` do not behave properly.

One resource is created for each chunk of the file received which obvsiouly does not help in any way with getting the complete content that we can expect. The fix here is to just let `NetworkAccessManager` do its job.

The second problem that was detected with this case is that `QtWebKit` emits `pageLoaded` even though the `QNetworkReply` object in charge of downloading the file is still running. Hence keep a registry of in-flight requests and only allow `wait_for_page_loaded` to return when both `pageLoaded` has been emited and no queries are still running.

This is basically what was reported in PR #265 hopefully with a clearer wording.