### PR TITLE
Allow timeout to be passed to session functions

### DIFF
--- a/ghost/ghost.py
+++ b/ghost/ghost.py
@@ -173,12 +173,12 @@ def can_load_page(func):
     @wraps(func)
     def wrapper(self, *args, **kwargs):
         expect_loading = kwargs.pop('expect_loading', False)
-
+        timeout = kwargs.pop('timeout', None)
         if expect_loading:
             self.loaded = False
             func(self, *args, **kwargs)
             return self.wait_for_page_loaded(
-                timeout=kwargs.pop('timeout', None))
+                timeout=timeout)
         return func(self, *args, **kwargs)
     return wrapper
 


### PR DESCRIPTION
Currently, the wrapper passes `timeout` along to the session function. However, functions like `click()` don't accept the timeout parameter so you end up with:

```
  File "ghost_test.py", line 17, in get_login_cookie
    session.click('#login', expect_loading=True, timeout=30)
  File "/usr/local/lib/python2.7/site-packages/ghost/ghost.py", line 179, in wrapper
    func(self, *args, **kwargs)
TypeError: click() got an unexpected keyword argument 'timeout'
```

This change moves popping timeout to before the invocation of `func` to fix the bug.